### PR TITLE
fix: remove duplicate id="content"

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
 <section id="content">
     <div class="container">
         <div id="markup">
-            <article id="content" class="markdown-body">
+            <article id="hero" class="markdown-body">
                 <h1 class="visually-hidden">pyinfra - Python Infrastructure Automation</h1>
                 <p class="big hero-text">pyinfra turns Python code into shell commands and runs them on your servers. Execute ad-hoc commands and write declarative operations. Target SSH servers, local machine and Docker containers. Fast and scales from one server to thousands.</p>
                 <p class="big comparison-text">Think <code>ansible</code> but Python instead of YAML, and <strong>up to 10x faster</strong>.</p>


### PR DESCRIPTION
## Summary

- Rename the inner `<article id="content">` to `id="hero"` so the page no longer has two elements sharing the same id (the outer `<section id="content">` keeps the original).
- Duplicate IDs are invalid HTML and are flagged by Lighthouse and most SEO crawlers. Neither id is referenced from CSS or JS, so this is a no-op visually.

## Test plan

- [ ] Open `index.html` locally, page renders identically
- [ ] Run Lighthouse, "Document avoids duplicate IDs" passes